### PR TITLE
Use https for the font link

### DIFF
--- a/src/sitegen/layout.cljs
+++ b/src/sitegen/layout.cljs
@@ -37,7 +37,7 @@
     [:title title]
     [:meta {:name "description" :content description}]
 
-    [:link {:rel "stylesheet" :href "http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700"}]
+    [:link {:rel "stylesheet" :href "https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700"}]
     [:link {:rel "stylesheet" :href "https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css"}]
     [:link {:rel "stylesheet" :href "/css/normalize.css"}]
     [:link {:rel "stylesheet" :href "/css/skeleton.css"}]


### PR DESCRIPTION
When you visit the site with https enabled chrome complains that there are untrusted sources. this commit addresses this by using https for the font link
